### PR TITLE
Add portfolio site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,18 @@
-# codex-v1
+# Codex Portfolio
 
-## Note
+This project is a simple portfolio website built with Next.js and Tailwind CSS.
 
-- sample
+## Getting Started
+
+Install dependencies and start the development server:
+
+```bash
+npm install
+npm run dev
+```
+
+Run lint checks:
+
+```bash
+npm run lint
+```

--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -1,0 +1,12 @@
+import Link from "next/link";
+
+export default function Header() {
+  return (
+    <header className="border-b mb-8 py-4">
+      <nav className="container mx-auto flex gap-4">
+        <Link href="/" className="font-semibold">Home</Link>
+        <Link href="/projects" className="font-semibold">Projects</Link>
+      </nav>
+    </header>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -8,8 +8,6 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
 }
 
 @media (prefers-color-scheme: dark) {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,16 +1,6 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
-
-const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
-});
+import Header from "./components/Header";
 
 export const metadata: Metadata = {
   title: "Create Next App",
@@ -24,9 +14,8 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
+      <body className="antialiased">
+        <Header />
         {children}
       </body>
     </html>

--- a/app/lib/projects.ts
+++ b/app/lib/projects.ts
@@ -1,0 +1,18 @@
+export type Project = {
+  title: string;
+  description: string;
+  repo: string;
+};
+
+export const projects: Project[] = [
+  {
+    title: "Portfolio",
+    description: "This website showcasing various projects.",
+    repo: "https://github.com/example/portfolio",
+  },
+  {
+    title: "Sample App",
+    description: "A simple demonstration application built with Next.js.",
+    repo: "https://github.com/example/sample-app",
+  },
+];

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,103 +1,13 @@
-import Image from "next/image";
+import Link from "next/link";
 
 export default function Home() {
   return (
-    <div className="grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20 font-[family-name:var(--font-geist-sans)]">
-      <main className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start">
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={180}
-          height={38}
-          priority
-        />
-        <ol className="list-inside list-decimal text-sm/6 text-center sm:text-left font-[family-name:var(--font-geist-mono)]">
-          <li className="mb-2 tracking-[-.01em]">
-            Get started by editing{" "}
-            <code className="bg-black/[.05] dark:bg-white/[.06] px-1 py-0.5 rounded font-[family-name:var(--font-geist-mono)] font-semibold">
-              app/page.tsx
-            </code>
-            .
-          </li>
-          <li className="tracking-[-.01em]">
-            Save and see your changes instantly.
-          </li>
-        </ol>
-
-        <div className="flex gap-4 items-center flex-col sm:flex-row">
-          <a
-            className="rounded-full border border-solid border-transparent transition-colors flex items-center justify-center bg-foreground text-background gap-2 hover:bg-[#383838] dark:hover:bg-[#ccc] font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 sm:w-auto"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={20}
-              height={20}
-            />
-            Deploy now
-          </a>
-          <a
-            className="rounded-full border border-solid border-black/[.08] dark:border-white/[.145] transition-colors flex items-center justify-center hover:bg-[#f2f2f2] dark:hover:bg-[#1a1a1a] hover:border-transparent font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 w-full sm:w-auto md:w-[158px]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Read our docs
-          </a>
-        </div>
-      </main>
-      <footer className="row-start-3 flex gap-[24px] flex-wrap items-center justify-center">
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/file.svg"
-            alt="File icon"
-            width={16}
-            height={16}
-          />
-          Learn
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/window.svg"
-            alt="Window icon"
-            width={16}
-            height={16}
-          />
-          Examples
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/globe.svg"
-            alt="Globe icon"
-            width={16}
-            height={16}
-          />
-          Go to nextjs.org →
-        </a>
-      </footer>
-    </div>
+    <main className="container mx-auto py-8">
+      <h1 className="text-3xl font-bold mb-4">My Code Portfolio</h1>
+      <p className="mb-6">Welcome to my collection of programming projects.</p>
+      <Link href="/projects" className="text-blue-500 underline">
+        View Projects
+      </Link>
+    </main>
   );
 }

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -1,0 +1,26 @@
+import Link from "next/link";
+import { projects } from "../lib/projects";
+
+export default function Projects() {
+  return (
+    <main className="container mx-auto py-8">
+      <h1 className="text-2xl font-bold mb-4">Projects</h1>
+      <ul className="space-y-4">
+        {projects.map((project) => (
+          <li key={project.title} className="border p-4 rounded">
+            <h2 className="text-xl font-semibold">{project.title}</h2>
+            <p className="mb-2">{project.description}</p>
+            <Link
+              href={project.repo}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-blue-500 underline"
+            >
+              View Repository
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- build a simple portfolio page
- add a projects listing page
- introduce a common header component
- update global styles and README

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68535a18138c832bb0851135764567a9