### PR TITLE
feat(portfolio): add portfolio pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # codex-v1
 
-## Note
+This is a simple Next.js portfolio site.
 
-- sample
+## Development
+
+Install dependencies and start the development server:
+
+```bash
+npm install
+npm run dev
+```

--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -1,0 +1,19 @@
+import Link from "next/link";
+
+export default function Header() {
+  return (
+    <header className="p-4 flex justify-between items-center border-b border-gray-200 dark:border-gray-800">
+      <h1 className="text-xl font-bold">
+        <Link href="/">My Portfolio</Link>
+      </h1>
+      <nav className="flex gap-4">
+        <Link href="/" className="hover:underline">
+          Home
+        </Link>
+        <Link href="/portfolio" className="hover:underline">
+          Portfolio
+        </Link>
+      </nav>
+    </header>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,16 +1,6 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
-
-const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
-});
+import Header from "./components/Header";
 
 export const metadata: Metadata = {
   title: "Create Next App",
@@ -24,10 +14,9 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
-        {children}
+      <body className="antialiased">
+        <Header />
+        <main className="p-4">{children}</main>
       </body>
     </html>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,5 @@
 import Image from "next/image";
+import Link from "next/link";
 
 export default function Home() {
   return (
@@ -49,6 +50,12 @@ export default function Home() {
           >
             Read our docs
           </a>
+          <Link
+            href="/portfolio"
+            className="rounded-full border border-solid border-black/[.08] dark:border-white/[.145] transition-colors flex items-center justify-center hover:bg-[#f2f2f2] dark:hover:bg-[#1a1a1a] hover:border-transparent font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 w-full sm:w-auto"
+          >
+            View portfolio
+          </Link>
         </div>
       </main>
       <footer className="row-start-3 flex gap-[24px] flex-wrap items-center justify-center">

--- a/app/portfolio/page.tsx
+++ b/app/portfolio/page.tsx
@@ -1,0 +1,53 @@
+export const metadata = {
+  title: "Portfolio",
+};
+
+interface Project {
+  title: string;
+  description: string;
+  url: string;
+}
+
+const projects: Project[] = [
+  {
+    title: "Project Alpha",
+    description: "Example Next.js project showcasing features.",
+    url: "https://example.com/alpha",
+  },
+  {
+    title: "Project Beta",
+    description: "Another sample project using React and TypeScript.",
+    url: "https://example.com/beta",
+  },
+  {
+    title: "Project Gamma",
+    description: "A creative project with Tailwind CSS styling.",
+    url: "https://example.com/gamma",
+  },
+];
+
+export default function PortfolioPage() {
+  return (
+    <div className="space-y-6">
+      <h2 className="text-2xl font-bold">Portfolio</h2>
+      <ul className="space-y-4">
+        {projects.map((project) => (
+          <li key={project.title} className="border p-4 rounded-md">
+            <h3 className="text-xl font-semibold">{project.title}</h3>
+            <p className="mb-2 text-sm text-gray-600 dark:text-gray-300">
+              {project.description}
+            </p>
+            <a
+              className="text-blue-600 hover:underline"
+              href={project.url}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              View project
+            </a>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- create a `Header` component with navigation links
- update layout to display the header
- add a portfolio page listing sample projects
- link to the portfolio page from the homepage
- update `README` with basic instructions

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685360e9b304832bacc910db5082e624