### PR TITLE
Add dedicated pages for portfolio projects

### DIFF
--- a/app/portfolio/alpha/page.tsx
+++ b/app/portfolio/alpha/page.tsx
@@ -1,0 +1,12 @@
+export const metadata = {
+  title: "Project Alpha",
+};
+
+export default function ProjectAlpha() {
+  return (
+    <div className="space-y-4">
+      <h2 className="text-2xl font-bold">Project Alpha</h2>
+      <p>This project explores a blogging platform built with Next.js. It demonstrates server-side rendering, dynamic routing, and Markdown support for content management.</p>
+    </div>
+  );
+}

--- a/app/portfolio/beta/page.tsx
+++ b/app/portfolio/beta/page.tsx
@@ -1,0 +1,12 @@
+export const metadata = {
+  title: "Project Beta",
+};
+
+export default function ProjectBeta() {
+  return (
+    <div className="space-y-4">
+      <h2 className="text-2xl font-bold">Project Beta</h2>
+      <p>Project Beta is a small browser-based puzzle game created with React and TypeScript. It focuses on gameplay mechanics and interactive animations.</p>
+    </div>
+  );
+}

--- a/app/portfolio/gamma/page.tsx
+++ b/app/portfolio/gamma/page.tsx
@@ -1,0 +1,12 @@
+export const metadata = {
+  title: "Project Gamma",
+};
+
+export default function ProjectGamma() {
+  return (
+    <div className="space-y-4">
+      <h2 className="text-2xl font-bold">Project Gamma</h2>
+      <p>Project Gamma showcases a photography portfolio using Tailwind CSS for responsive layouts and dark mode support.</p>
+    </div>
+  );
+}

--- a/app/portfolio/page.tsx
+++ b/app/portfolio/page.tsx
@@ -2,27 +2,29 @@ export const metadata = {
   title: "Portfolio",
 };
 
+import Link from "next/link";
+
 interface Project {
   title: string;
   description: string;
-  url: string;
+  path: string;
 }
 
 const projects: Project[] = [
   {
     title: "Project Alpha",
-    description: "Example Next.js project showcasing features.",
-    url: "https://example.com/alpha",
+    description: "Blog platform built with Next.js.",
+    path: "/portfolio/alpha",
   },
   {
     title: "Project Beta",
-    description: "Another sample project using React and TypeScript.",
-    url: "https://example.com/beta",
+    description: "Browser-based puzzle game.",
+    path: "/portfolio/beta",
   },
   {
     title: "Project Gamma",
-    description: "A creative project with Tailwind CSS styling.",
-    url: "https://example.com/gamma",
+    description: "Photography portfolio with Tailwind CSS.",
+    path: "/portfolio/gamma",
   },
 ];
 
@@ -37,14 +39,9 @@ export default function PortfolioPage() {
             <p className="mb-2 text-sm text-gray-600 dark:text-gray-300">
               {project.description}
             </p>
-            <a
-              className="text-blue-600 hover:underline"
-              href={project.url}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
+            <Link href={project.path} className="text-blue-600 hover:underline">
               View project
-            </a>
+            </Link>
           </li>
         ))}
       </ul>


### PR DESCRIPTION
## Summary
- add separate pages for Project Alpha, Beta, and Gamma
- link portfolio items to the new pages

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68568a179564832bb1730705dad96f86